### PR TITLE
feat: misc - --no-color, --abi fl;ag priority, and fix chunked read of input JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   Options parameter | Description
   ------------------|------------------------------------------------------------
   -p, --pragma <pragma> | add Solidity pragma expression (default: "solidity >=0.7.0 <0.9.0")
-  -o, --output <filename> | specify a name for an output file. Writes to standart output by default
+  -o, --output <filename> | specify a name for an output file. When unspecified, reads from the standard input
   -a, --abi <filename> | specify a name for the ABI JSON file (default: "abi.json")
   --no-color | disable colored syntax hinglighting in the Terminal window
   -V, --version | output the version number

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   -p, --pragma <pragma> | add Solidity pragma expression (default: "solidity >=0.7.0 <0.9.0")
   -o, --output <filename> | specify a name for an output file. Writes to standart output by default
   -a, --abi <filename> | specify a name for the ABI JSON file (default: "abi.json")
+  --no-color | disable colored syntax hinglighting in the Terminal window
   -V, --version | output the version number
   -h, --help | display help for command
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   try {
     // read user specified options
-    const { outputFilename, pragma, abiFilename } = parseCLI();
+    const { outputFilename, pragma, abiFilename, color } = parseCLI();
     // Accept ABI JSON file from stdin stream or from provided file
     const abi = await readABI(abiFilename);
     // only select function signatures from the ABI
@@ -27,7 +27,7 @@ async function main() {
       );
     } else {
       // paint the text with colors if output to the console
-      colors.enable();
+      colors[color ? 'enable' : 'disable']();
       writeInterface(functions, pragma, process.stdout);
     }
   } catch (error) {

--- a/src/parseCLI.js
+++ b/src/parseCLI.js
@@ -15,8 +15,7 @@ function parseCLI() {
     )
     .option(
       '-a, --abi <filename>',
-      'specify a name for the ABI JSON file',
-      'abi.json',
+      'specify a name for the ABI JSON file. Reads from standart input by default',
     );
   program.parse();
   const { output: outputFilename, pragma, abi: abiFilename } = program.opts();

--- a/src/parseCLI.js
+++ b/src/parseCLI.js
@@ -16,9 +16,18 @@ function parseCLI() {
     .option(
       '-a, --abi <filename>',
       'specify a name for the ABI JSON file. Reads from standart input by default',
+    )
+    .option(
+      '--no-color',
+      'disable colored syntax hinglighting in the Terminal window',
     );
   program.parse();
-  const { output: outputFilename, pragma, abi: abiFilename } = program.opts();
-  return { outputFilename, pragma, abiFilename };
+  const {
+    output: outputFilename,
+    pragma,
+    abi: abiFilename,
+    color,
+  } = program.opts();
+  return { outputFilename, pragma, abiFilename, color };
 }
 export default parseCLI;

--- a/src/parseCLI.js
+++ b/src/parseCLI.js
@@ -15,7 +15,7 @@ function parseCLI() {
     )
     .option(
       '-a, --abi <filename>',
-      'specify a name for the ABI JSON file. Reads from standart input by default',
+      'specify a name for the ABI JSON file. When unspecified, reads from the standard input',
     )
     .option(
       '--no-color',

--- a/src/readABI.js
+++ b/src/readABI.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 
-const DEFAULT_ABI_FILE = 'abi.json';
 /**
  * First tries to read ABI from --abi (-a) command line parameter,
  * then from stdin, and lastly from the default filename
@@ -35,15 +34,6 @@ function readABI(filename) {
       stdin.on('error', () => {
         reject(Error('Error reading ABI file'));
       });
-      // if a file was not specified in stdin either, try to read the default file
-      setTimeout(() => {
-        stdin.pause();
-        try {
-          resolve(JSON.parse(fs.readFileSync(DEFAULT_ABI_FILE)));
-        } catch (error) {
-          reject(error);
-        }
-      }, 100);
     }
   });
 }

--- a/src/readABI.js
+++ b/src/readABI.js
@@ -1,35 +1,50 @@
 import fs from 'fs';
+
+const DEFAULT_ABI_FILE = 'abi.json';
 /**
- * First tries to read ABI from stdin, then from --abi (-a)
- * command line parameter.
+ * First tries to read ABI from --abi (-a) command line parameter,
+ * then from stdin, and lastly from the default filename
  * @param {string} filename user specified or default ABI filename
  * @returns {Promise<[]>} ABI interface
  */
 function readABI(filename) {
-  const { stdin } = process;
-  stdin.setEncoding('utf8');
   return new Promise((resolve, reject) => {
-    // trying to read a file from stdin (command line)
-    stdin.on('data', (file) => {
-      try {
-        resolve(JSON.parse(file));
-      } catch (error) {
-        reject(error);
-      }
-    });
-    stdin.on('error', () => {
-      reject(Error('Error reading ABI file'));
-    });
     // trying to read a file from --abi command line parameter
-    // or from a default filename
-    setTimeout(() => {
+    if (filename) {
       try {
-        stdin.pause();
         resolve(JSON.parse(fs.readFileSync(filename)));
       } catch (error) {
         reject(error);
       }
-    }, 50);
+
+      // if --abi param was not specified, try to read from stdin
+    } else {
+      const { stdin } = process;
+      stdin.setEncoding('utf8');
+      const chunks = [];
+      stdin.on('data', (chunk) => {
+        chunks.push(chunk);
+      });
+      stdin.on('end', () => {
+        try {
+          resolve(JSON.parse(chunks.join('')));
+        } catch (error) {
+          reject(error);
+        }
+      });
+      stdin.on('error', () => {
+        reject(Error('Error reading ABI file'));
+      });
+      // if a file was not specified in stdin either, try to read the default file
+      setTimeout(() => {
+        stdin.pause();
+        try {
+          resolve(JSON.parse(fs.readFileSync(DEFAULT_ABI_FILE)));
+        } catch (error) {
+          reject(error);
+        }
+      }, 100);
+    }
   });
 }
 export default readABI;


### PR DESCRIPTION
- add a CLI flag --no-color to disable syntax highlighting
- add 'chunks' array to store temporary data before parsing JSON file coming from STDIN
- change the order of reading ABI file: first try to read from the command line, then from STDIN, then from the default file